### PR TITLE
/vaults/{chain}/harvests/{since}

### DIFF
--- a/src/queries/VaultsHarvests.graphql
+++ b/src/queries/VaultsHarvests.graphql
@@ -1,0 +1,28 @@
+query VaultsHarvests($since: BigInt!, $first: Int = 1000, $skip: Int = 0) {
+  beefyCLVaults(first: $first, skip: $skip, where: { lifecycle_not: INITIALIZING }) {
+    vaultAddress: id
+    underlyingToken0 {
+      decimals
+    }
+    underlyingToken1 {
+      decimals
+    }
+    sharesToken {
+      decimals
+    }
+    harvests(
+      orderBy: timestamp
+      orderDirection: desc
+      first: 1000
+      where: { timestamp_gte: $since }
+    ) {
+      timestamp
+      compoundedAmount0
+      compoundedAmount1
+      token0ToNativePrice
+      token1ToNativePrice
+      nativeToUSDPrice
+      totalSupply
+    }
+  }
+}

--- a/src/queries/VaultsHarvestsFiltered.graphql
+++ b/src/queries/VaultsHarvestsFiltered.graphql
@@ -1,0 +1,37 @@
+query VaultsHarvestsFiltered(
+  $since: BigInt!
+  $first: Int = 1000
+  $skip: Int = 0
+  $vaults: [Bytes!]!
+) {
+  beefyCLVaults(
+    first: $first
+    skip: $skip
+    where: { lifecycle_not: INITIALIZING, id_in: $vaults }
+  ) {
+    vaultAddress: id
+    underlyingToken0 {
+      decimals
+    }
+    underlyingToken1 {
+      decimals
+    }
+    sharesToken {
+      decimals
+    }
+    harvests(
+      orderBy: timestamp
+      orderDirection: desc
+      first: 1000
+      where: { timestamp_gte: $since }
+    ) {
+      timestamp
+      compoundedAmount0
+      compoundedAmount1
+      token0ToNativePrice
+      token1ToNativePrice
+      nativeToUSDPrice
+      totalSupply
+    }
+  }
+}

--- a/src/routes/v1/vaults.ts
+++ b/src/routes/v1/vaults.ts
@@ -9,12 +9,14 @@ import { pick } from 'lodash';
 import { VaultsQuery } from '../../../.graphclient/index';
 import { calculateLastApr, prepareAprState } from '../../utils/apr';
 import { interpretAsDecimal } from '../../utils/decimal';
+import { PreparedVaultHarvest, prepareVaultHarvests } from './vault';
 
 export default async function (
   instance: FastifyInstance,
   _opts: FastifyPluginOptions,
   done: (err?: Error) => void
 ) {
+  // vaults data for use by main api
   {
     type UrlParams = {
       chain: ChainId;
@@ -41,6 +43,45 @@ export default async function (
       const result = await getVaults(chain, period);
       reply.send(result);
     });
+  }
+
+  // Vaults harvest data
+  {
+    type UrlParams = {
+      chain: ChainId;
+      since: number;
+    };
+
+    const urlParamsSchema = S.object()
+      .prop(
+        'chain',
+        chainSchema.required().description('The chain to return vaults harvest data for')
+      )
+      .prop(
+        'since',
+        S.number().required().description('The unix timestamp to return harvests since')
+      );
+
+    const responseSchema = S.array().items(S.object());
+
+    const schema: FastifySchema = {
+      tags: ['v1'],
+      params: urlParamsSchema,
+      response: {
+        200: responseSchema,
+      },
+    };
+
+    instance.get<{ Params: UrlParams }>(
+      '/:chain/harvests/:since',
+      { schema },
+      async (request, reply) => {
+        const { chain, since } = request.params;
+
+        const result = await getVaultsHarvests(chain, since);
+        reply.send(result);
+      }
+    );
   }
 
   done();
@@ -88,4 +129,28 @@ const getVaultApy = (vault: VaultsQuery['beefyCLVaults'][0], periodSeconds: numb
   );
 
   return calculateLastApr(aprState, periodSeconds * 1000, now);
+};
+
+const getVaultsHarvests = async (chain: ChainId, since: number) => {
+  const rawVaults = await sdk
+    .VaultsHarvests({ since: since.toString() }, { chainName: chain })
+    .catch((e: unknown) => {
+      throw new GraphQueryError(e);
+    });
+
+  return rawVaults.beefyCLVaults.reduce(
+    (acc, vault) => {
+      if (vault.harvests.length === 0) {
+        return acc;
+      }
+
+      acc.push({
+        vaultAddress: vault.vaultAddress,
+        harvests: prepareVaultHarvests(vault),
+      });
+
+      return acc;
+    },
+    [] as { vaultAddress: string; harvests: PreparedVaultHarvest[] }[]
+  );
 };


### PR DESCRIPTION
Have auto-paging on the vaults, which means only 1000 harvests can be returned per vault, we'll have to implement our own paging in the future

![image](https://github.com/beefyfinance/beefy-clm-api/assets/55021052/04278857-676b-4cdc-a799-b89b0fb94f11)

since param - can limit harvests to those that only happened after the users first deposit on a chain

```json
[
  {
    "vaultAddress": "0x2a2e016f9c30c7da5a41b21c19e9619ff78ab673",
    "harvests": [
      {
        "timestamp": "1716804723",
        "compoundedAmount0": "19.016622116330283777",
        "compoundedAmount1": "0.032746575060818259",
        "token0ToUsd": "7.0562494565713384261605102",
        "token1ToUsd": "3900.40941318",
        "totalSupply": "42.725547566967262999"
      },
      // ...
    ]
  },
  {
    "vaultAddress": "0x4c32b8d26e6ab2ce401772514c999768f63afb4e",
    "harvests": [
      {
        "timestamp": "1716801097",
        "compoundedAmount0": "0.003531314277863657",
        "compoundedAmount1": "17.133168",
        "token0ToUsd": "4560.414382266754964228",
        "token1ToUsd": "0.9990578425598518968",
        "totalSupply": "0.000000089912270828"
      },
      // ...
    ]
  },
  // ...
]
```