### PR TITLE
Fix APR calculation

### DIFF
--- a/src/queries/Vaults.graphql
+++ b/src/queries/Vaults.graphql
@@ -25,6 +25,17 @@ query Vaults($since: BigInt!, $first: Int = 1000, $skip: Int = 0) {
       underlyingToNativePrice
       nativeToUSDPrice
     }
+    latestCollectedFees: harvests(
+      first: 5
+      orderBy: timestamp
+      orderDirection: desc
+    ) {
+      timestamp
+      underlyingAmount
+      compoundedAmount
+      underlyingToNativePrice
+      nativeToUSDPrice
+    }
   }
   clms(first: $first, skip: $skip, where: { lifecycle_not: INITIALIZING }) {
     vaultAddress: id
@@ -40,6 +51,19 @@ query Vaults($since: BigInt!, $first: Int = 1000, $skip: Int = 0) {
     collectedFees: collections(
       first: 1000
       where: { timestamp_gte: $since }
+      orderBy: timestamp
+      orderDirection: desc
+    ) {
+      timestamp
+      underlyingAmount0
+      underlyingAmount1
+      collectedAmount0
+      collectedAmount1
+      token0ToNativePrice
+      token1ToNativePrice
+    }
+    latestCollectedFees: collections(
+      first: 2
       orderBy: timestamp
       orderDirection: desc
     ) {

--- a/src/utils/apr.test.ts
+++ b/src/utils/apr.test.ts
@@ -85,7 +85,7 @@ describe('Apr', () => {
     expect(res.apr.toNumber()).toEqual(ZERO_BD.toNumber());
   });
 
-  test('Should calculate APR with one entry only, non regression for 0% apr on uniswap-cow-arb-weth-usdc.e-prod', async () => {
+  test('Should calculate APR with one entry only, should be 0', async () => {
     const aprState = [
       {
         collectedAmount: new Decimal('0.00032000437230484107316'),
@@ -98,6 +98,24 @@ describe('Apr', () => {
 
     expect(res.apr.toNumber()).toBeCloseTo(0, 3);
     expect(res.apy.toNumber()).toBeCloseTo(0, 3);
+  });
+
+  test('Should calculate APR with 1 entry in current period with additional entry previous to it', async () => {
+    const aprState = [
+      {
+        collectedAmount: new Decimal('1.52862409877410972716'),
+        collectTimestamp: new Date('2025-04-10T00:49:05.000Z'), //Entry happening over 24h from desired period
+        totalValueLocked: new Decimal('23960.55152220372208423456'),
+      },
+      {
+        collectedAmount: new Decimal('156.67283090769483794841'),
+        collectTimestamp: new Date('2025-04-12T11:28:58.000Z'), //Only entry falling into the 1day period
+        totalValueLocked: new Decimal('22026.66919334588149167308'),
+      },
+    ];
+
+    const res = calculateLastApr(aprState, 86400 * 1000, new Date('2025-04-12T11:28:58.000Z'));
+    expect(res.apr.toNumber()).toBeCloseTo(0.9763914502623975, 3);
   });
 
   test('should compute apr in the simplest case', () => {

--- a/src/utils/apr.test.ts
+++ b/src/utils/apr.test.ts
@@ -68,7 +68,7 @@ describe('Apr', () => {
     ]);
     const now = new Date(69382400 * 1000);
     aprState = evictOldAprEntries(aprState, ONE_DAY, now);
-    expect(aprState.length).toEqual(2);
+    expect(aprState.length).toEqual(3);
   });
 
   test('should compute apr properly with one entry of zero duration', () => {
@@ -96,8 +96,8 @@ describe('Apr', () => {
 
     const res = calculateLastApr(aprState, 86400 * 1000, new Date('2024-06-18T07:26:11.773Z'));
 
-    expect(res.apr.toNumber()).toBeCloseTo(0.45586, 3);
-    expect(res.apy.toNumber()).toBeCloseTo(0.57709, 3);
+    expect(res.apr.toNumber()).toBeCloseTo(0, 3);
+    expect(res.apy.toNumber()).toBeCloseTo(0, 3);
   });
 
   test('should compute apr in the simplest case', () => {

--- a/src/utils/apr.test.ts
+++ b/src/utils/apr.test.ts
@@ -4,6 +4,7 @@ import {
   aprToApy,
   calculateLastApr,
   evictOldAprEntries,
+  mergeUnique,
   prepareAprState,
 } from './apr';
 
@@ -17,6 +18,60 @@ describe('Apr', () => {
     const now = new Date(ONE_WEEK);
     const res = calculateLastApr(aprState, ONE_DAY, now);
     expect(res.apr.toNumber()).toEqual(ZERO_BD.toNumber());
+  });
+
+  test('merges arrays correctly', () => {
+    const baseArray: {
+      __typename?: 'ClassicHarvestEvent';
+      timestamp: string;
+      underlyingAmount: string;
+      compoundedAmount: string;
+      underlyingToNativePrice: string;
+      nativeToUSDPrice: string;
+    }[] = [
+      {
+        timestamp: '1711201231',
+        underlyingAmount: '100',
+        compoundedAmount: '100',
+        underlyingToNativePrice: '1',
+        nativeToUSDPrice: '1',
+      },
+      {
+        timestamp: '1711201235',
+        underlyingAmount: '100',
+        compoundedAmount: '100',
+        underlyingToNativePrice: '1',
+        nativeToUSDPrice: '1',
+      },
+    ];
+
+    const extraArray: {
+      __typename?: 'ClassicHarvestEvent';
+      timestamp: string;
+      underlyingAmount: string;
+      compoundedAmount: string;
+      underlyingToNativePrice: string;
+      nativeToUSDPrice: string;
+    }[] = [
+      {
+        //duplicate item, shouldn't be added
+        timestamp: '1711201231',
+        underlyingAmount: '100',
+        compoundedAmount: '100',
+        underlyingToNativePrice: '1',
+        nativeToUSDPrice: '1',
+      },
+      {
+        timestamp: '1711201236',
+        underlyingAmount: '100',
+        compoundedAmount: '100',
+        underlyingToNativePrice: '1',
+        nativeToUSDPrice: '1',
+      },
+    ];
+
+    const mergedArray = mergeUnique(baseArray, extraArray);
+    expect(mergedArray.length).toEqual(3);
   });
 
   test('do not crash when TVL is zero now', () => {

--- a/src/utils/apr.ts
+++ b/src/utils/apr.ts
@@ -36,9 +36,23 @@ export function prepareAprState(state: AprState): AprState {
   return cleanedEntries;
 }
 
+// Keeps entry prior to the threshold so we can compute the APR since then
 export function evictOldAprEntries(state: AprState, periodMs: number, now: Date): AprState {
   const threshold = now.getTime() - periodMs;
-  return state.filter(entry => entry.collectTimestamp.getTime() >= threshold);
+
+  // We keep the last entry prior to the threshold so we can compute the APR since then
+  const firstEntryAfterThresholdIndex = state.findIndex(
+    entry => entry.collectTimestamp.getTime() >= threshold
+  );
+  if (firstEntryAfterThresholdIndex === -1) {
+    return [];
+  }
+
+  return state.slice(
+    firstEntryAfterThresholdIndex - 1 >= 0
+      ? firstEntryAfterThresholdIndex - 1
+      : firstEntryAfterThresholdIndex
+  );
 }
 
 export function calculateLastApr(
@@ -65,29 +79,9 @@ export function calculateLastApr(
   state = evictOldAprEntries(state, periodMs, now);
 
   // special cases for 0 or 1 entries after eviction
-  if (state.length === 0) {
+  if (state.length <= 1) {
     return { apr: ZERO_BD, apy: ZERO_BD };
   }
-
-  if (state.length === 1) {
-    const entry = state[0];
-    const sliceDuration = new Decimal(now.getTime() - entry.collectTimestamp.getTime());
-    const sliceCollected = entry.collectedAmount;
-    const sliceTvl = entry.totalValueLocked;
-
-    if (sliceTvl.isZero()) {
-      return { apr: ZERO_BD, apy: ZERO_BD };
-    }
-    if (sliceDuration.isZero()) {
-      return { apr: ZERO_BD, apy: ZERO_BD };
-    }
-
-    const rewardRate = sliceCollected.div(sliceTvl).div(sliceDuration);
-    const apr = rewardRate.times(ONE_YEAR);
-    const apy = aprToApy(apr, ONE_YEAR / periodMs);
-    return { apr, apy };
-  }
-
   // for each time slice, we get the APR and duration for it
   const APRs = new Array<Decimal>();
   const durations = new Array<Decimal>();

--- a/src/utils/apr.ts
+++ b/src/utils/apr.ts
@@ -1,4 +1,5 @@
 import Decimal from 'decimal.js';
+import { isEqual } from 'lodash';
 import { getLoggerFor } from './log';
 
 const logger = getLoggerFor('AprState');
@@ -139,4 +140,17 @@ export function aprToApy(apr: Decimal, annualCompounds: number): Decimal {
   // APY = [1 + (r ÷ n)] ^ n – 1
   // where r is the APR and n is the number of compounding periods
   return apr.div(annualCompounds).plus(1).pow(annualCompounds).minus(1);
+}
+
+export function mergeUnique<T>(baseArray: T[], extraArray: T[]): T[] {
+  const result = [...baseArray];
+
+  for (const item of extraArray) {
+    // only add if no existing item matches
+    if (!result.some(existing => isEqual(existing, item))) {
+      result.push(item);
+    }
+  }
+
+  return result;
 }


### PR DESCRIPTION
We keep the entry prior to the threshold so we can know over what period current rewards were earned over.

Enforce 2 APR entries needed to calculate APR (only 1 of these entries necessarily needs to be in the time window, the other one would be the prior one we are now using as well) cause we need the window over which those rewards were earned, otherwise time window for the apr could be so small it threw the apr number to infinity if query times aligned