### PR TITLE
Add underscores to args

### DIFF
--- a/src/queries/codegen/codegen.ts
+++ b/src/queries/codegen/codegen.ts
@@ -8,6 +8,7 @@ const config: CodegenConfig = {
     'src/queries/codegen/sdk.ts': {
       plugins: ['typescript', 'typescript-operations', 'typescript-graphql-request'],
       config: {
+        addUnderscoreToArgsType: true, // avoid duplicate Args type names (e.g. ClmPositionSnapshotsArgs)
         rawRequest: true,
         strictScalars: true,
         scalars: {


### PR DESCRIPTION
Running `npm install` generates the codegen but with duplicate `ClmPositionSnapshotsArgs` and `ClassicPositionSnapshotsArgs`. Adding underscores to args fixes this issue.